### PR TITLE
explicit heading reference

### DIFF
--- a/notebooks/01-foundations/rendering-techniques.ipynb
+++ b/notebooks/01-foundations/rendering-techniques.ipynb
@@ -11,6 +11,7 @@
     "     align=\"right\"\n",
     "/>\n",
     "\n",
+    "(rendering-techniques)=\n",
     "# Rendering Techniques\n",
     "\n",
     "### In this section, you'll learn:\n",


### PR DESCRIPTION
Warning given for implicit heading reference from 01-foundations/plotting-libs to rendering-techniques

Looks like the cfconventions site is currently down, should retry tomorrow.
