### PR TITLE
Fix plots missing from notebooks: Geographic Projections & Features / Comparison to Xarray

### DIFF
--- a/notebooks/03-plotting-with-uxarray/compare-xarray.ipynb
+++ b/notebooks/03-plotting-with-uxarray/compare-xarray.ipynb
@@ -172,7 +172,7 @@
    },
    "outputs": [],
    "source": [
-    "uxds[\"psi\"].plot(width=800, height=400, backend=\"matplotlib\", cmap=\"inferno\");"
+    "uxds[\"psi\"].plot(width=800, height=400, backend=\"matplotlib\", cmap=\"inferno\")"
    ]
   },
   {
@@ -230,7 +230,7 @@
     "        height=400,\n",
     "        periodic_elements=\"split\",\n",
     "    )\n",
-    ").cols(1);"
+    ").cols(1)"
    ]
   }
  ],

--- a/notebooks/03-plotting-with-uxarray/geo.ipynb
+++ b/notebooks/03-plotting-with-uxarray/geo.ipynb
@@ -103,7 +103,7 @@
    "outputs": [],
    "source": [
     "projection = ccrs.Orthographic()\n",
-    "projection;"
+    "projection"
    ]
   },
   {
@@ -118,7 +118,7 @@
    },
    "outputs": [],
    "source": [
-    "uxds[\"bottomDepth\"].plot.polygons(projection=projection);"
+    "uxds[\"bottomDepth\"].plot.polygons(projection=projection)"
    ]
   },
   {
@@ -144,7 +144,7 @@
    "outputs": [],
    "source": [
     "projection = ccrs.Orthographic(central_longitude=-180)\n",
-    "projection;"
+    "projection"
    ]
   },
   {
@@ -159,7 +159,7 @@
    },
    "outputs": [],
    "source": [
-    "uxds[\"bottomDepth\"].plot.polygons(projection=projection);"
+    "uxds[\"bottomDepth\"].plot.polygons(projection=projection)"
    ]
   },
   {
@@ -188,7 +188,7 @@
    "source": [
     "uxds[\"bottomDepth\"].plot.polygons(\n",
     "    projection=projection, features=[\"borders\", \"coastline\"]\n",
-    ");"
+    ")"
    ]
   },
   {
@@ -213,7 +213,7 @@
    "source": [
     "uxds[\"bottomDepth\"].plot.polygons(\n",
     "    projection=projection, features={\"borders\": \"10m\", \"coastline\": \"10m\"}\n",
-    ");"
+    ")"
    ]
   }
  ],


### PR DESCRIPTION
Closes #45.

The online versions of the Geographic Projections & Features notebook (https://projectpythia.org/unstructured-grid-viz-cookbook/notebooks/plotting-with-uxarray/geo/) and the Comparison to Xarray notebook (https://projectpythia.org/unstructured-grid-viz-cookbook/notebooks/plotting-with-uxarray/compare-xarray/) were missing many plots. geo.ipynb was not displaying any plots, while compare-xarray.ipynb was only displaying one 1 of 3 plots.

This was related to ending cells with semicolons; removing the semicolons causes the plots to be displayed correctly, at least when I try to run the code on my machine.